### PR TITLE
Formatting times

### DIFF
--- a/apiTypes.go
+++ b/apiTypes.go
@@ -524,7 +524,24 @@ func (a *ApiRelTime) UnmarshalJSON(b []byte) (err error) {
 // -- ApiRelTime implementation
 
 func (a ApiRelTime) String() string {
-	return time.Duration(a).String()
+	var h = int64(time.Duration(a).Hours())
+	var m = int64(time.Duration(a).Minutes())
+	var s = int64(time.Duration(a).Seconds())
+	s -= m * 60
+	m -= h * 60
+
+	var t = ""
+	if h != 0 {
+		t = fmt.Sprintf("%dh", h)
+	}
+	if m != 0 {
+		t += fmt.Sprintf("%dm", m)
+	}
+	if s != 0 {
+		t += fmt.Sprintf("%ds", s)
+	}
+
+	return t
 }
 
 func (a ApiRelTime) Duration() time.Duration {
@@ -536,7 +553,13 @@ func (a ApiTime) Time() time.Time {
 }
 
 func (a ApiTime) String() string {
-	return time.Time(a).String()
+	var now = time.Now()
+	var tt = time.Time(a)
+	if tt.Year() == now.Year() && tt.Month() == now.Month() && tt.Day() == now.Day() {
+		return tt.Format("3:04:05pm today")
+	} else {
+		return tt.Format("3:04:05pm on January 2, 2006")
+	}
 }
 
 func (a ApiTime) Before(b ApiTime) bool {


### PR DESCRIPTION
We stuck with the default Duration and Time format so far, but to me these are a bit hard to read and verbose for humans. I propose we change the duration to only show h/m/s values when they are non-zero, and to change the date format to a simple local time and either the date or 'today'.

This affects any output with time (submissions, clarifications), but the contest output shows both. It would go from:
```
Contests (2):
   Id      Name                    Start Time                     Length  Status
   finals  ICPC World Finals 2019  2019-04-04 06:50:25 -0400 EDT  5h0m0s  Contest over
   comm    practice                2020-02-21 09:57:00 -0500 EST  2h0m0s  Contest over
```
to:
```
Contests (2):
   Id      Name                    Start Time                      Length  Status
   comm    practice                9:57:00am on February 21, 2020  2h      Contest over
   finals  ICPC World Finals 2019  4:51:56pm today                 5h      Scheduled
```